### PR TITLE
Update C_Mutex.java

### DIFF
--- a/C_Mutex.java
+++ b/C_Mutex.java
@@ -17,10 +17,11 @@ public class C_mutex extends Thread{
     }
 
     public void run(){
-	try{ 
+	try (ServerSocket ss_back = new ServerSocket(7001)) { 
 	    //  >>>  Listening from the server socket on port 7001
 	    // from where the TOKEN will be returned later.
-	    ServerSocket ss_back = new ServerSocket(7001);
+		
+	    // edit- i moved "serverSocket..."because i got a message =Resource leak: 'ss_back' is never closed
 		
 	    while (true){
 		// >>> Print some info on the current buffer content for debugging purposes.
@@ -29,19 +30,30 @@ public class C_mutex extends Thread{
 		System.out.println("C:mutex   Buffer size is "+ buffer.size());
 		
 		// if the buffer is not empty
-		if ( ) {		    
+		if (buffer.size( ) >0 ) {		    
 
 		    // >>>   Getting the first (FIFO) node that is waiting for a TOKEN form the buffer
 		    //       Type conversions may be needed.
 
-		    n_host = 
-		    n_port = ;
+			Object obj = buffer.get();
+			if(obj instanceof String[]);
+			String[] nodeInfo = (String[]) obj;
+
+		    n_host = nodeInfo[0];
+		    n_port = Integer.parseInt(nodeInfo[1]) ;
 		    
 		    
 		    // >>>  **** Granting the token
 		    //
 		    try{
-		
+		//Kate add more  =// Connect to the node's indicated port to grant the token
+                s = new Socket(n_host, n_port);
+                // Assuming you need to send some message to grant the token
+                // You can customize this part based on your implementation
+                // Example: PrintWriter out = new PrintWriter(s.getOutputStream(), true);
+                // out.println("TOKEN_GRANT_MESSAGE");
+                // out.close();
+                s.close();
 		    }
 		    catch (java.io.IOException e) {
 				System.out.println(e);
@@ -51,7 +63,10 @@ public class C_mutex extends Thread{
 			    
 		    //  >>>  **** Getting the token back
 		    try{
-				// THIS IS BLOCKING !
+			// THIS IS BLOCKING !
+		    	Socket tokenBackSocket = ss_back.accept();
+		    	//Kate- add more here ? 
+		    	tokenBackSocket.close();
 		    }
 		    catch (java.io.IOException e) {
 				System.out.println(e);


### PR DESCRIPTION
/Here's a breakdown of the changes:
//Getting Node Info from Buffer: Retrieve the node information from the buffer. Since the buffer may contain objects of different types, we need to check the type before casting and extracting the node information. //Granting the Token: Connect to the node's indicated port to grant the token. You may customize this part based on your implementation. //Getting the Token Back: Accept the token back from the node. This part is blocking until a token is returned. You can add more handling here if needed.